### PR TITLE
Hide APIkey using config.js and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/config.js
+++ b/config.js
@@ -1,0 +1,4 @@
+const config = { 
+    apiKey : '', // Add your OpenWeatherMap api key
+    googleApiKey: '', // Add your Google api key
+  }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./style.css">
+  <script src="./config.js" defer></script>
   <script src="./script.js" defer></script>
   <link rel="icon" type="image/png" href="x-icon.png"/>
 </head>

--- a/script.js
+++ b/script.js
@@ -5,8 +5,8 @@ let weather = {
   tempField: document.querySelector(".temp"),
   humidityField: document.querySelector(".humidity"),
   windField: document.querySelector(".wind"),
-  apiKey: "5e1ddb8233f281231d95bf6718bddbb8",
-  googleApiKey: "", // Add your google api key
+  apiKey: config.apiKey,
+  googleApiKey: config.googleApiKey, 
   changeVisibilty: function (fields, value) {
     for (let field of fields) {
       field.style.visibility = value;


### PR DESCRIPTION
Fixes #10 
The API keys can be added to `config.js` once the repo is downloaded, since it is in `.gitignore`, even if someone accidentally pushes to their repo without removing the keys, the keys won't be pushed.